### PR TITLE
[Face Landmarks] Add ability to output detection confidence to landmarks bottle

### DIFF
--- a/faceLandmarks/include/faceLandmarks.h
+++ b/faceLandmarks/include/faceLandmarks.h
@@ -51,7 +51,6 @@
 #include <iostream>
 #include <string>
 #include <iomanip>
-#include <algorithm>
 
 #include "faceLandmarks_IDLServer.h"
 

--- a/faceLandmarks/include/faceLandmarks.h
+++ b/faceLandmarks/include/faceLandmarks.h
@@ -51,6 +51,7 @@
 #include <iostream>
 #include <string>
 #include <iomanip>
+#include <algorithm>
 
 #include "faceLandmarks_IDLServer.h"
 


### PR DESCRIPTION
The `dlib` documentation shows that, if we call the faceDetector in faceLandmarks a bit differently we can also get a measurement of how confident the detection is[^1].

This is information that could be relevant to whoever uses the module. E.g. to discriminate only if the face detection is over a certain threshold of confidence.

This PR adds the detection confidence of each landmark as part of the output bottle of `/faceLandmarks/landmarks:o`. It is put at the end of the bottle so as to not affect compatibility with previous apps that use the module.

[^1]: [dlib docs](http://dlib.net/dlib/image_processing/object_detector_abstract.h.html#:~:text=dets%5Bi%5D.detection_confidence%20%3D%3D%20The%20strength%20of%20the%20i%2Dth%20detection)