### PR TITLE
faceLandmarks: removed unused and deprecated RateThread

### DIFF
--- a/faceLandmarks/CMakeLists.txt
+++ b/faceLandmarks/CMakeLists.txt
@@ -13,9 +13,6 @@ find_package(Threads)
 
 list(APPEND CMAKE_MODULE_PATH ${ICUBCONTRIB_MODULE_PATH})
 
-#adding c++11 flags
-set(CMAKE_CXX_FLAGS "-std=c++14")
-
 include(ICUBcontribHelpers)
 include(ICUBcontribOptions)
 
@@ -39,7 +36,12 @@ include_directories(${PROJECT_SOURCE_DIR}/include
 
 add_executable(${PROJECT_NAME} ${source} ${header} ${doc} ${idl} ${IDL_GEN_FILES})
 
-target_link_libraries(${PROJECT_NAME} dlib::dlib ${YARP_LIBRARIES} ${OpenCV_LIBRARIES}  )
+target_link_libraries(${PROJECT_NAME} dlib::dlib
+                                      YARP::YARP_os
+                                      YARP::YARP_conf
+                                      YARP::YARP_init
+                                      YARP::YARP_sig
+                                      ${OpenCV_LIBRARIES}  )
 
 install(TARGETS ${PROJECT_NAME} DESTINATION bin)
 yarp_install(FILES ${doc} DESTINATION ${ICUBCONTRIB_MODULES_INSTALL_DIR})

--- a/faceLandmarks/include/faceLandmarks.h
+++ b/faceLandmarks/include/faceLandmarks.h
@@ -22,7 +22,6 @@
 #include <yarp/os/RFModule.h>
 #include <yarp/os/Network.h>
 #include <yarp/os/Thread.h>
-#include <yarp/os/RateThread.h>
 #include <yarp/os/Time.h>
 #include <yarp/os/Semaphore.h>
 #include <yarp/os/Stamp.h>


### PR DESCRIPTION
Moreover removed CMAKE_CXX_FLAGS -std=c++14 letting deciding YARP which is the standard to use