### PR TITLE
[yarpRTMPose] Fix cmake hardcoded path

### DIFF
--- a/yarpRTMPose/CMakeLists.txt
+++ b/yarpRTMPose/CMakeLists.txt
@@ -4,17 +4,23 @@ project(yarpRTMPose LANGUAGES CXX VERSION 0.2)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(ENABLE_tests OFF CACHE BOOL "Enable tests")
 
 find_package(YARP 3.2.2 REQUIRED COMPONENTS os sig dev math cv)
-find_package(ICUBcontrib REQUIRED)
 find_package(MMDeploy REQUIRED)
 find_package(OpenCV REQUIRED)
 
 set(INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/src/c++/include)
 set(THIRD_PARTY ${CMAKE_CURRENT_SOURCE_DIR}/src/c++/thirdparty)
 
+# Add MMDeploy example dirs to include utils/visualize.h
+set(MMDeploy_EXAMPLE_DIR ${MMDeploy_DIR}/../../../example/cpp/cpp)
+
 add_subdirectory(src/c++)
-add_subdirectory(tests)
+
+if(ENABLE_tests)
+    add_subdirectory(src/tests)
+endif()
 
 file(GLOB conf ${CMAKE_CURRENT_SOURCE_DIR}/app/conf/yarpRTMPose.ini)
 file(GLOB grabber_conf ${CMAKE_CURRENT_SOURCE_DIR}/app/conf/grabber.ini)

--- a/yarpRTMPose/src/c++/CMakeLists.txt
+++ b/yarpRTMPose/src/c++/CMakeLists.txt
@@ -6,7 +6,7 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 add_executable(${PROJECT_NAME} include/yarpRTMPose.h src/yarpRTMPose.cpp main.cpp)
 
 target_include_directories(${PROJECT_NAME} PRIVATE ${PROJECT_SOURCE_DIR}/include ${PROJECT_SOURCE_DIR}/thirdparty)
-target_include_directories(${PROJECT_NAME} PRIVATE /usr/local/example/cpp/cpp)
+target_include_directories(${PROJECT_NAME} PRIVATE ${MMDeploy_EXAMPLE_DIR})
 target_link_libraries(${PROJECT_NAME} PRIVATE mmdeploy ${OpenCV_LIBS} ${YARP_LIBRARIES})
 
 install(TARGETS ${PROJECT_NAME} DESTINATION bin)


### PR DESCRIPTION
## Fix

- Now cmakelists is independent of mmdeploy installation path
- Removed icubcontrib package from cmake